### PR TITLE
EC2にWordPress環境を構築。

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AWSのEC2上にWordPress環境を作成するためのスクリプト
 1. 他の項目は任意に設定して、起動してください。
 1. sshで起動したEC2にログインします。
 ```
-ssh -i xxx.pem ec2-user@xx.xx.xx.xx
+ssh -i xxx.pem ec2-user@www.hogehoge.com
 ```
 
 ### 2. Nginx1.x / PHP7.2 / MariaDB10のインストール
@@ -24,24 +24,24 @@ chmod 744 install-lnmp.sh
 ```
 2. ブラウザでページが参照できるか確認してください。
 ```
-http://xx.xx.xx.xx
+http://www.hogehoge.com
 ```
 
 ### 3. WordPressのインストール
 
 1. 以下のコマンドを実行してください。
-（最後のシェル実行ではデータベース名を指定します）
+（最後のシェル実行では新規サイトのFQDNを指定します）
 ```
 cd ~
 wget https://github.com/tri-comma/ec2-wordpress-builer/install-wordpress.sh
 chmod 744 install-wordpress.sh
-./install-wordpress.sh wordpress
+./install-wordpress.sh www.hogehoge.com
 ```
 2. ブラウザでWordPressのインストールを開始してください。
 ```
-http://xx.xx.xx.xx/wordpress
+http://www.hogehoge.com
 ```
-- データベース名：シェル実行時に指定した名称
+- データベース名：FQDNのドットおよびハイフンをアンダースコアに変換した名称
 - ユーザ名：root
 - パスワード：なし
 - ホスト名：localhost

--- a/README.md
+++ b/README.md
@@ -26,3 +26,23 @@ chmod 744 install-lnmp.sh
 ```
 http://xx.xx.xx.xx
 ```
+
+### 3. WordPressのインストール
+
+1. 以下のコマンドを実行してください。
+（最後のシェル実行ではデータベース名を指定します）
+```
+cd ~
+wget https://github.com/tri-comma/ec2-wordpress-builer/install-wordpress.sh
+chmod 744 install-wordpress.sh
+./install-wordpress.sh wordpress
+```
+2. ブラウザでWordPressのインストールを開始してください。
+```
+http://xx.xx.xx.xx/wordpress
+```
+- データベース名：シェル実行時に指定した名称
+- ユーザ名：root
+- パスワード：なし
+- ホスト名：localhost
+- テーブル接頭子：wp_（任意に設定可能）

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # ec2-wordpress-builer
 AWSのEC2上にWordPress環境を作成するためのスクリプト
+
+## 使い方
+
+### 1. EC2の起動
+
+1. AWS ConsoleでEC2を新規作成します。
+1. AMIは `Amazon Linux 2` を選択してください。
+1. 他の項目は任意に設定して、起動してください。
+1. sshで起動したEC2にログインします。
+```
+ssh -i xxx.pem ec2-user@xx.xx.xx.xx
+```
+
+### 2. Nginx1.x / PHP7.2 / MariaDB10のインストール
+
+1. 以下のコマンドを実行してください。
+```
+cd ~
+wget https://github.com/tri-comma/ec2-wordpress-builer/install-lnmp.sh
+chmod 744 install-lnmp.sh
+```
+2. ブラウザでページが参照できるか確認してください。
+```
+http://xx.xx.xx.xx
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ssh -i xxx.pem ec2-user@xx.xx.xx.xx
 cd ~
 wget https://github.com/tri-comma/ec2-wordpress-builer/install-lnmp.sh
 chmod 744 install-lnmp.sh
+./install-lnmp.sh
 ```
 2. ブラウザでページが参照できるか確認してください。
 ```

--- a/install-lnmp.sh
+++ b/install-lnmp.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/bash
+
+if test "`cat /etc/system-release`" != "Amazon Linux release 2 (Karoo)"; then exit 2; fi
+# Amazon Linux release 2 (Karoo)
+
+sudo sudo yum -y update
+sudo amazon-linux-extras install nginx1 -y
+# install nginx.x86_64 1:1.16.1-1.amzn2.0.1 at 2020.4.18
+
+sudo amazon-linux-extras install php7.2 -y
+# install php7.2.28 at 2020.4.18
+#   php-json-7.2.28-1.amzn2.x86_64
+#   php-common-7.2.28-1.amzn2.x86_64
+#   php-pdo-7.2.28-1.amzn2.x86_64
+#   php-mysqlnd-7.2.28-1.amzn2.x86_64
+#   php-cli-7.2.28-1.amzn2.x86_64
+#   php-fpm-7.2.28-1.amzn2.x86_64
+sudo yum -y install php-devel php-mbstring php-pecl-apcu php-opcache
+sudo cp /etc/php-fpm.d/www.conf /etc/php-fpm.d/www.conf.origin
+sudo sed -i -e 's/ = apache$/ = nginx/g' /etc/php-fpm.d/www.conf
+
+sudo yum -y install mariadb-server
+# install mariadb-server.x86_64 1:5.5.64-1.amzn2 at 2020.4.18
+
+sudo systemctl start php-fpm.service
+sudo systemctl enable php-fpm.service
+sudo systemctl start nginx.service
+sudo systemctl enable nginx.service
+sudo systemctl start mariadb
+sudo systemctl enable mariadb
+
+exit 0

--- a/install-wordpress.sh
+++ b/install-wordpress.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+if [ $# -ne 1 ]; then
+	echo "作成するデータベース名を指定してください。"
+	echo "ex. $ ./install-wordpress.sh wordpress"
+	exit 1
+fi
+
+cd ~
+if [ -f ./latest-ja.zip ]; then
+	sudo mv latest-ja.zip latest-ja.zip.`date "+%Y%m%d_%H%M%S"`
+fi
+wget http://ja.wordpress.org/latest-ja.zip
+unzip ~/latest-ja.zip
+sudo mv ~/wordpress /usr/share/nginx/html/
+sudo chown -R nginx:nginx /usr/share/nginx/html/wordpress
+
+mysql -u root -e "CREATE DATABASE $1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;" 
+
+exit 0
+
+
+

--- a/install-wordpress.sh
+++ b/install-wordpress.sh
@@ -20,7 +20,7 @@ sudo mv ~/wordpress/* /usr/share/nginx/vhosts/$FQDN/
 sudo rmdir ~/wordpress
 sudo chown -R nginx:nginx /usr/share/nginx/vhosts/$FQDN
 
-sudo cat << __NGINX_CONF__ > /etc/nginx/conf.d/$FQDN.conf
+sudo cat << __NGINX_CONF__ | sudo tee /etc/nginx/conf.d/$FQDN.conf > /dev/null
 server {
     listen 80;
     server_name $FQDN;

--- a/install-wordpress.sh
+++ b/install-wordpress.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/bash
 
 if [ $# -ne 1 ]; then
-	echo "作成するデータベース名を指定してください。"
-	echo "ex. $ ./install-wordpress.sh wordpress"
+	echo "作成するサイトのFQDNを指定してください。"
+	echo "ex. $ ./install-wordpress.sh www.hogehoge.com"
 	exit 1
 fi
+FQDN=$1
 
 cd ~
 if [ -f ./latest-ja.zip ]; then
@@ -12,12 +13,34 @@ if [ -f ./latest-ja.zip ]; then
 fi
 wget http://ja.wordpress.org/latest-ja.zip
 unzip ~/latest-ja.zip
-sudo mv ~/wordpress /usr/share/nginx/html/
-sudo chown -R nginx:nginx /usr/share/nginx/html/wordpress
+rm ~/latest-ja.zip
 
-mysql -u root -e "CREATE DATABASE $1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;" 
+sudo mkdir -p /usr/share/nginx/vhosts/$FQDN
+sudo mv ~/wordpress/* /usr/share/nginx/vhosts/$FQDN/
+sudo rmdir ~/wordpress
+sudo chown -R nginx:nginx /usr/share/nginx/vhosts/$FQDN
+
+sudo cat << __NGINX_CONF__ > /etc/nginx/conf.d/$FQDN.conf
+server {
+    listen 80;
+    server_name $FQDN;
+    access_log /var/log/nginx/$FQDN-access.log main;
+    error_log /var/log/nginx/$FQDN-error.log;
+    root /usr/share/nginx/vhosts/$FQDN;
+    index index.php index.html;
+    location ~ \.php$ {
+        root /usr/share/nginx/vhosts/$FQDN;
+        fastcgi_pass unix:/var/run/php-fpm/www.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        include fastcgi_params;
+    }
+}
+__NGINX_CONF__
+
+DBNAME=`echo $FQDN | sed s/\\\./_/g | sed s/-/_/g`
+mysql -u root -e "CREATE DATABASE $DBNAME DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;" 
+
+sudo systemctl restart nginx.service
 
 exit 0
-
-
-


### PR DESCRIPTION
新規作成されたEC2インスタンスにNignx・PHP・MariaDBをインストール。
WordPressはDB名称を指定してインストール。
作成するEC2インスタンスのAMIはAmazonLinux2のみを想定。